### PR TITLE
Partition based bug

### DIFF
--- a/dummy_spark/rdd.py
+++ b/dummy_spark/rdd.py
@@ -172,13 +172,7 @@ class RDD(object):
         return self.map(f)
 
     def foreachPartition(self, f):
-        def func(it):
-            r = f(it)
-            try:
-                return iter(r)
-            except TypeError:
-                return iter([])
-        self.mapPartitions(func).count()
+        return f(self._jrdd)
 
     def collect(self):
         return self._jrdd


### PR DESCRIPTION
Spark RDDs pass iterables to foreachPartition unlike foreach (which gets every row of the rdd one at a time). This means we have to pass the full list into foreachPartition in DummyRDD to keep witht spark api