### PR TITLE
Fields returns as a list

### DIFF
--- a/dummy_spark/context.py
+++ b/dummy_spark/context.py
@@ -398,7 +398,9 @@ class SparkContext(object):
                 if '_source' in dat.keys():
                     cleaned_data.append((dat.get('_id'), dat.get('_source', {})))
                 elif 'fields' in dat.keys():
-                    cleaned_data.append((dat.get('_id'), dat.get('fields')))
+                    cleaned_data.append((dat.get('_id'),
+                                         {k: v[0] for k, v
+                                          in dat.get('fields').items()}))
 
             rdd = RDD(cleaned_data, self, None)
 


### PR DESCRIPTION
In a normal spark context, fields would get moved from list to the first value.
DummyRDD needs to mirror this functionality