### PR TITLE
Fix crashing RDD methods takeSample(withReplacement=True) and zip

### DIFF
--- a/dummy_spark/rdd.py
+++ b/dummy_spark/rdd.py
@@ -240,7 +240,7 @@ class RDD(object):
             random.seed(seed)
 
         if withReplacement:
-            out = [self._jrdd[random.choice(list(range(len(self._jrdd))))] for _ in num]
+            out = [self._jrdd[random.choice(list(range(len(self._jrdd))))] for _ in range(num)]
         else:
             idx_list = list(range(len(self._jrdd)))
             random.shuffle(idx_list)
@@ -466,7 +466,7 @@ class RDD(object):
         :param other:
         :return:
         """
-        data = list(zip(other, self._jrdd))
+        data = list(zip(self._jrdd, other._jrdd))
         return RDD(data, self.ctx)
 
     def zipWithIndex(self):

--- a/tests/unit/test_rdd.py
+++ b/tests/unit/test_rdd.py
@@ -391,6 +391,36 @@ class RDDTests (unittest.TestCase):
         rdd2 = sc.parallelize([('A', None), ('C', None)])
         self.assertListEqual(rdd1.subtractByKey(rdd2).collect(), [('B', 2)])
 
+    def test_take_sample_with_replacement(self):
+        for start, stop, step in self.TEST_RANGES:
+            l = list(range(start, stop, step))
+            rdd = RDD(l, self.SPARK_CONTEXT)
+            num = min(len(l), 5)
+            sample = rdd.takeSample(True, num)
+            self.assertEqual(len(sample), num)
+            for item in sample:
+                self.assertTrue(item in l)
+
+    def test_take_sample_without_replacement(self):
+        for start, stop, step in self.TEST_RANGES:
+            l = list(range(start, stop, step))
+            rdd = RDD(l, self.SPARK_CONTEXT)
+            num = min(len(l), 5)
+            sample = rdd.takeSample(False, num)
+            self.assertEqual(len(sample), num)
+            self.assertEqual(len(sample), len(set(sample)))
+            for item in sample:
+                self.assertTrue(item in l)
+
+    def test_zip(self):
+        sc = SparkContext(master='', conf=SparkConf())
+        rdd1 = sc.parallelize([1, 2, 3, 4, 5])
+        rdd2 = sc.parallelize([10, 20, 30, 40, 50])
+        self.assertListEqual(
+            rdd1.zip(rdd2).collect(),
+            [(1, 10), (2, 20), (3, 30), (4, 40), (5, 50)]
+        )
+
     def test_not_implemented_methods(self):
         sc = SparkContext(master='', conf=SparkConf())
         rdd = sc.parallelize([])


### PR DESCRIPTION
Closes #38

## What changed
Two documented public RDD methods raised `TypeError` on ordinary usage and had no test coverage.

- **`takeSample(withReplacement=True, num)`** (`dummy_spark/rdd.py`): iterated `for _ in num` where `num` is an int → `TypeError: 'int' object is not iterable`. Changed to `for _ in range(num)`, matching the `withReplacement=False` branch.
- **`zip(other)`** (`dummy_spark/rdd.py`): used `zip(other, self._jrdd)`, but `other` is an `RDD` with no `__iter__` → `TypeError: 'RDD' object is not iterable`; the pair order was also reversed vs PySpark. Changed to `zip(self._jrdd, other._jrdd)` so it accepts an RDD and yields `(self, other)` pairs in the correct order.

Added unit tests in `tests/unit/test_rdd.py` covering `takeSample` (with and without replacement) and `zip` (pairing and order).

Note: new test assertions use `assertEqual`/`assertListEqual` (the file's prevailing `assertEquals` alias is removed in Python 3.12+, so it would fail on modern interpreters regardless of this change).

## Verification
Ran the three new tests with pytest (Python 3.13 via `uv`). The package's import of `dummy_spark` currently fails on Python 3.10+ due to the unrelated `collections.Iterable` removal (issue #36, not yet on master), so I applied that import fix locally **only to run the tests** and reverted it — it is not part of this PR.

```
tests/unit/test_rdd.py::RDDTests::test_zip PASSED
tests/unit/test_rdd.py::RDDTests::test_take_sample_with_replacement PASSED
tests/unit/test_rdd.py::RDDTests::test_take_sample_without_replacement PASSED
3 passed
```