### PR TITLE
Fix reversed ascending order in repartitionAndSortWithinPartitions

### DIFF
--- a/dummy_spark/rdd.py
+++ b/dummy_spark/rdd.py
@@ -283,7 +283,7 @@ class RDD(object):
         :param keyfunc:
         :return:
         """
-        data = sorted(self._jrdd, key=keyfunc, reverse=ascending)
+        data = sorted(self._jrdd, key=keyfunc, reverse=not ascending)
         return RDD(data, self.ctx)
 
     def sortByKey(self, ascending=True, numPartitions=None, keyfunc=lambda x: x):

--- a/tests/unit/test_rdd.py
+++ b/tests/unit/test_rdd.py
@@ -385,6 +385,30 @@ class RDDTests (unittest.TestCase):
         )
         self.assertListEqual(rdd.collect(), [5, 4, 3, 2, 1])
 
+    def test_repartitionAndSortWithinPartitions_ascending(self):
+        sc = SparkContext(master='', conf=SparkConf())
+        rdd = (
+            sc.parallelize([5, 4, 3, 2, 1])
+            .repartitionAndSortWithinPartitions(ascending=True)
+        )
+        self.assertListEqual(rdd.collect(), [1, 2, 3, 4, 5])
+
+    def test_repartitionAndSortWithinPartitions_descending(self):
+        sc = SparkContext(master='', conf=SparkConf())
+        rdd = (
+            sc.parallelize([1, 2, 3, 4, 5])
+            .repartitionAndSortWithinPartitions(ascending=False)
+        )
+        self.assertListEqual(rdd.collect(), [5, 4, 3, 2, 1])
+
+    def test_repartitionAndSortWithinPartitions_keyfunc(self):
+        sc = SparkContext(master='', conf=SparkConf())
+        rdd = (
+            sc.parallelize([('a', 3), ('b', 1), ('c', 2)])
+            .repartitionAndSortWithinPartitions(ascending=True, keyfunc=lambda x: x[1])
+        )
+        self.assertListEqual(rdd.collect(), [('b', 1), ('c', 2), ('a', 3)])
+
     def test_subtractByKey(self):
         sc = SparkContext(master='', conf=SparkConf())
         rdd1 = sc.parallelize([('A', 1), ('B', 2), ('C', 3)])


### PR DESCRIPTION
Closes #37

## What changed
`RDD.repartitionAndSortWithinPartitions` used `reverse=ascending`, which made the default `ascending=True` produce a **descending** result. Changed to `reverse=not ascending`, matching the already-fixed `sortBy`/`sortByKey` (PR #33).

Added three tests in `tests/unit/test_rdd.py` covering `ascending=True`, `ascending=False`, and a custom `keyfunc`.

## Verification
Ran the sort tests on Python 3.9 (the suite can't import on 3.10+ due to the unrelated `collections.Iterable` bug, issue #36):

```
uv run --python 3.9 --with pytest python -m pytest tests/unit/test_rdd.py \
  -k "repartitionAndSort or sortBy or sortByKey"
# 7 passed, 25 deselected
```

The three new `repartitionAndSortWithinPartitions` tests pass, alongside the existing `sortBy`/`sortByKey` tests.