### PR TITLE
Fix Python 3.10+ import crash from removed collections.Iterable

### DIFF
--- a/dummy_spark/resultsiterable.py
+++ b/dummy_spark/resultsiterable.py
@@ -17,12 +17,12 @@
 # limitations under the License.
 #
 
-import collections
+import collections.abc
 
 __all__ = ["ResultIterable"]
 
 
-class ResultIterable(collections.Iterable):
+class ResultIterable(collections.abc.Iterable):
 
     """
     A special result iterable. This is used because the standard


### PR DESCRIPTION
Closes #36

## Summary
`dummy_spark/resultsiterable.py` subclassed `collections.Iterable`, a legacy alias deprecated in Python 3.3 and **removed in 3.10**. Because `dummy_spark/__init__.py` imports `ResultIterable` transitively, the entire package raised `AttributeError: module 'collections' has no attribute 'Iterable'` on any Python 3.10+ interpreter, making it unusable on modern Python.

## Change
- `import collections` → `import collections.abc`
- `class ResultIterable(collections.Iterable)` → `class ResultIterable(collections.abc.Iterable)`

Scoped to `dummy_spark/resultsiterable.py` only. `collections.abc.Iterable` is the documented, long-standing location (works on 3.3+) and behaves identically. No other `collections.Iterable`/`Mapping`/`Sequence` aliases remain in the codebase (verified via grep; `rdd.py` only imports `OrderedDict`, which is unaffected).

Note (out of scope): `.travis.yml` only tests up to Python 3.5, and the test suite uses the `assertEquals` alias removed in 3.12+ — CI modernization is left for a separate change.

## Verification
- `uv run --python 3.13 python -c "from dummy_spark import SparkContext, SparkConf"` → succeeds.
- `isinstance(ResultIterable([]), collections.abc.Iterable)` → `True`.
- `uv run --python 3.11 --with pytest python -m pytest tests/` → **50 passed** (only `assertEquals` deprecation warnings, pre-existing and out of scope). Run on 3.11 since the suite's `assertEquals` usage errors on 3.12+, independent of this fix.