### PR TITLE
Fix scalar leftOuterJoin semantics

### DIFF
--- a/dummy_spark/rdd.py
+++ b/dummy_spark/rdd.py
@@ -869,10 +869,16 @@ class RDD(object):
         """
 
         result_dict = {}
-        for x in other._jrdd:
-            result_dict[x[0]] = result_dict.setdefault(x[0], []) + x[1]
+        for key, value in other._jrdd:
+            result_dict.setdefault(key, []).append(value)
 
-        data = [(k, (v, result_dict.get(k))) for k, v in self._jrdd]
+        data = []
+        for key, value in self._jrdd:
+            matches = result_dict.get(key)
+            if matches is None:
+                data.append((key, (value, None)))
+            else:
+                data.extend((key, (value, match)) for match in matches)
         return RDD(data, self.ctx)
 
     def rightOuterJoin(self, other, numPartitions=None):

--- a/tests/unit/test_rdd.py
+++ b/tests/unit/test_rdd.py
@@ -279,11 +279,27 @@ class RDDTests (unittest.TestCase):
 
     def test_left_outer_join(self):
         sc = SparkContext(master='', conf=SparkConf())
-        rdd1 = sc.parallelize([('A', [1, 2, 3]), ('B', [2,3,4])])
-        rdd2 = sc.parallelize([('A', [1, 2, 3]), ('B', [2,3,4]), ('B', [4,5,6])])
-        out = rdd1.leftOuterJoin(rdd2).collect()
-        print(out)
-        self.assertEqual(len(out), 2)
+        left = sc.parallelize([
+            ('A', 1),
+            ('A', 2),
+            ('B', 3),
+            ('C', [4, 5]),
+        ])
+        right = sc.parallelize([
+            ('A', 10),
+            ('A', 20),
+            ('C', [6, 7]),
+            ('D', 30),
+        ])
+
+        self.assertListEqual(left.leftOuterJoin(right).collect(), [
+            ('A', (1, 10)),
+            ('A', (1, 20)),
+            ('A', (2, 10)),
+            ('A', (2, 20)),
+            ('B', (3, None)),
+            ('C', ([4, 5], [6, 7])),
+        ])
 
     def test_keys(self):
         sc = SparkContext(master='', conf=SparkConf())
@@ -571,6 +587,5 @@ class RDDTests (unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             rdd._to_java_object_rdd()
-
 
 


### PR DESCRIPTION
Closes #44

## Summary

- group right-side values by key without assuming or flattening their types
- emit one result for every left/right match, including duplicate keys on both sides
- emit `None` for unmatched left records and omit right-only keys
- replace the length-only test with exact scalar, duplicate, unmatched, right-only, and list-valued assertions

## Verification

- `uv run --with pytest python -m pytest tests/unit/test_rdd.py::RDDTests::test_left_outer_join -q` — 1 passed
- `uv run --python 3.9 --with pytest python -m pytest tests/ -q` — 56 passed
- Restored the original concatenating implementation as a mutation, verified it landed with `rg`, and confirmed the focused test failed with the scalar `TypeError`; then restored the fix and reran the focused test successfully.
