### PR TITLE
Preserve duplicate records in pair-RDD projections

### DIFF
--- a/dummy_spark/rdd.py
+++ b/dummy_spark/rdd.py
@@ -490,7 +490,7 @@ class RDD(object):
         :param key:
         :return:
         """
-        return [x for x in self._jrdd if x[0] == key]
+        return [value for pair_key, value in self._jrdd if pair_key == key]
 
     def countApprox(self, timeout, confidence=0.95):
         """
@@ -823,7 +823,7 @@ class RDD(object):
         :return: A new RDD that contains only the original pair RDD keys
 
         """
-        return RDD(list(OrderedDict(self._jrdd).keys()), self.ctx)
+        return RDD([key for key, _ in self._jrdd], self.ctx)
 
     def values(self):
         """Get values of a pair RDD.
@@ -831,7 +831,7 @@ class RDD(object):
         :return: A new RDD that contains only the original pair RDD values
 
         """
-        return RDD(list(OrderedDict(self._jrdd).values()), self.ctx)
+        return RDD([value for _, value in self._jrdd], self.ctx)
 
     def reduceByKeyLocally(self, func):
         """

--- a/tests/unit/test_rdd.py
+++ b/tests/unit/test_rdd.py
@@ -303,13 +303,19 @@ class RDDTests (unittest.TestCase):
 
     def test_keys(self):
         sc = SparkContext(master='', conf=SparkConf())
-        rdd = sc.parallelize([('A', 1), ('B', 2), ('C', 3)])
-        self.assertListEqual(rdd.keys().collect(), ['A', 'B', 'C'])
+        rdd = sc.parallelize([('A', 1), ('A', 2), ('B', 3), ('A', 4)])
+        self.assertListEqual(rdd.keys().collect(), ['A', 'A', 'B', 'A'])
 
     def test_values(self):
         sc = SparkContext(master='', conf=SparkConf())
-        rdd = sc.parallelize([('A', 1), ('B', 2), ('C', 3)])
-        self.assertListEqual(rdd.values().collect(), [1, 2, 3])
+        rdd = sc.parallelize([('A', 1), ('A', 2), ('B', 3), ('A', 4)])
+        self.assertListEqual(rdd.values().collect(), [1, 2, 3, 4])
+
+    def test_lookup(self):
+        sc = SparkContext(master='', conf=SparkConf())
+        rdd = sc.parallelize([('A', 1), ('A', 2), ('B', 3), ('A', 4)])
+        self.assertListEqual(rdd.lookup('A'), [1, 2, 4])
+        self.assertListEqual(rdd.lookup('missing'), [])
 
     def test_combineByKey(self):
         sc = SparkContext(master='', conf=SparkConf())


### PR DESCRIPTION
Closes #43

## Summary

- project every source pair in `keys()` and `values()`, preserving duplicates and input order
- return matching values rather than `(key, value)` pairs from `lookup()`
- cover repeated keys, projection order, matching lookups, and missing keys

## Verification

- `uv run --python 3.12 --with pytest python -m pytest tests -q` — 57 passed
- `uv run --python 3.13 --with pytest python -m pytest tests -q` — 57 passed
- `git diff --check` — passed
- Reinstated the prior implementations and ran the focused projection tests — all three failed; restored the fix and reran the full Python 3.12 suite successfully